### PR TITLE
Skip from external doc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0.4'
-          - '3.1.2'
-          - '3.2.0-preview1'
+          - '3.0.6'
+          - '3.1.4'
+          - '3.2.2'
 
     steps:
     - uses: actions/checkout@v3

--- a/Rakefile
+++ b/Rakefile
@@ -13,18 +13,19 @@ task :sig do
   require 'orthoses-yard'
   require 'pathname'
 
-  Pathname('sig').rmtree rescue nil
   Orthoses::Builder.new do
     use Orthoses::CreateFileByName,
-      base_dir: 'sig',
-      header: '# GENERATED FILE'
+      depth: 1,
+      to: 'sig',
+      header: '# GENERATED FILE',
+      rmtree: true
     use Orthoses::Filter do |name, _|
       name.start_with?('Orthoses::YARD')
     end
     use Orthoses::YARD,
-      parse: 'lib/orthoses/**/*.rb'
+      parse: Dir.glob("lib/**/*.rb").grep_v(/_test\.rb\z/)
     run -> {}
   end.call
 end
 
-task default: :test
+task default: [:test, :sig]

--- a/lib/orthoses/yard.rb
+++ b/lib/orthoses/yard.rb
@@ -17,11 +17,17 @@ module Orthoses
 
         ::YARD.parse(@parse)
         ::YARD::Registry.root.children.each do |yardoc|
+          # Skip anonymous yardoc
+          next unless yardoc.file
+
+          # Skip external doc (e.g. pry-doc)
+          next unless @parse.any? { |pattern| File.fnmatch(pattern, yardoc.file) }
+
           case yardoc.type
           when :class, :module
             YARD2RBS.run(yardoc: yardoc) do |namespace, docstring, rbs|
               comment = docstring.each_line.map { |line| "# #{line}" }.join
-              if rbs.nil?
+              if rbs.nil? && comment && !store.has_key?(namespace)
                 store[namespace].comment = comment
               else
                 Orthoses.logger.debug("#{namespace} << #{rbs}")

--- a/lib/orthoses/yard.rb
+++ b/lib/orthoses/yard.rb
@@ -11,6 +11,7 @@ module Orthoses
       @parse = Array(parse)
     end
 
+    # @return [void]
     def call
       @loader.call.tap do |store|
         require 'yard'

--- a/sig/orthoses.rbs
+++ b/sig/orthoses.rbs
@@ -1,5 +1,13 @@
 # GENERATED FILE
 
+# use Orthoses::YARD, parse: "lib/**/*.rb"
+class Orthoses::YARD
+  def initialize: (untyped loader, parse: untyped) -> void
+  # @return [void]
+  def call: () -> void
+  VERSION: untyped
+end
+
 class Orthoses::YARD::YARD2RBS
   # @return [YARD::CodeObjects::t]
   attr_reader yardoc: untyped
@@ -20,6 +28,8 @@ class Orthoses::YARD::YARD2RBS
   def generate_for_methods: () -> void
   # @return [void]
   def generate_for_constants: () -> void
+  # @return [void]
+  def generate_for_classvariable: () -> void
   # @return [RBS::Types::t]
   def tag_types_to_rbs_type: (untyped tag_types) -> untyped
   # @return [RBS::Types::t]

--- a/sig/orthoses/yard.rbs
+++ b/sig/orthoses/yard.rbs
@@ -1,6 +1,0 @@
-# GENERATED FILE
-
-class Orthoses::YARD
-  def initialize: (untyped loader, parse: untyped) -> void
-  VERSION: untyped
-end


### PR DESCRIPTION
For example, when `pry-doc` is required, it registers the built-in class for `yardoc` in the registry. Since these are not easily recognized as targets to be generated, and their loaded status cannot be guaranteed, they are excluded from the targets.