### PR TITLE
Skip no typed method, const, cvar and attribute

### DIFF
--- a/lib/orthoses/yard.rb
+++ b/lib/orthoses/yard.rb
@@ -37,12 +37,12 @@ module Orthoses
           case yardoc.type
           when :class, :module
             YARD2RBS.run(yardoc: yardoc) do |namespace, docstring, rbs|
-              comment = docstring.each_line.map { |line| "# #{line}" }.join
+              comment = docstring.empty? ? '' : "# #{docstring.gsub("\n", "\n# ")}"
               if rbs.nil? && comment && !store.has_key?(namespace)
                 store[namespace].comment = comment
               else
                 Orthoses.logger.debug("#{namespace} << #{rbs}")
-                store[namespace] << "#{comment}\n#{rbs}"
+                store[namespace] << "#{comment.chomp}\n#{rbs}"
               end
             end
           end

--- a/sig/orthoses.rbs
+++ b/sig/orthoses.rbs
@@ -9,7 +9,6 @@ class Orthoses::YARD
   def initialize: (untyped loader, parse: Array[String] | String, ?use_cache: bool, ?log_level: Symbol?) -> void
   # @return [void]
   def call: () -> void
-  VERSION: untyped
 end
 
 class Orthoses::YARD::YARD2RBS
@@ -23,7 +22,6 @@ class Orthoses::YARD::YARD2RBS
   attr_reader void: RBS::Types::Bases::Void
   # @return [RBS::Types::Bases::Bool]
   attr_reader bool: RBS::Types::Bases::Bool
-  def initialize: (yardoc: untyped, block: untyped) -> void
   # @return [void]
   def run: () -> void
   # @return [RBS::Types::t]


### PR DESCRIPTION
If a tag doesn't exist, generating a type inadvertently overwrites the type. If the tag doesn't exist, a type should not be generated.