### PR TITLE
Add `allow_empty_doc` option

### DIFF
--- a/lib/orthoses/yard.rb
+++ b/lib/orthoses/yard.rb
@@ -10,11 +10,13 @@ module Orthoses
     # @param [<String>, String] parse Target files
     # @param [Boolean] use_cache Use cache .yardoc
     # @param [Symbol, nil] log_level Set YARD log level
-    def initialize(loader, parse:, use_cache: true, log_level: nil)
+    # @param [Boolean] allow_empty_doc Generate RBS also from empty doc
+    def initialize(loader, parse:, use_cache: true, log_level: nil, allow_empty_doc: false)
       @loader = loader
       @parse = Array(parse)
       @use_cache = use_cache
       @log_level = log_level
+      @allow_empty_doc = allow_empty_doc
     end
 
     # @return [void]
@@ -36,7 +38,8 @@ module Orthoses
 
           case yardoc.type
           when :class, :module
-            YARD2RBS.run(yardoc: yardoc) do |namespace, docstring, rbs|
+            YARD2RBS.run(yardoc: yardoc) do |namespace, docstring, rbs, skippable|
+              next if skippable && !@allow_empty_doc
               comment = docstring.empty? ? '' : "# #{docstring.gsub("\n", "\n# ")}"
               if rbs.nil? && comment && !store.has_key?(namespace)
                 store[namespace].comment = comment

--- a/sig/orthoses.rbs
+++ b/sig/orthoses.rbs
@@ -6,7 +6,8 @@ class Orthoses::YARD
   # @param [<String>, String] parse Target files
   # @param [Boolean] use_cache Use cache .yardoc
   # @param [Symbol, nil] log_level Set YARD log level
-  def initialize: (untyped loader, parse: Array[String] | String, ?use_cache: bool, ?log_level: Symbol?) -> void
+  # @param [Boolean] allow_empty_doc Generate RBS also from empty doc
+  def initialize: (untyped loader, parse: Array[String] | String, ?use_cache: bool, ?log_level: Symbol?, ?allow_empty_doc: bool) -> void
   # @return [void]
   def call: () -> void
 end


### PR DESCRIPTION
It has been determined that it would be beneficial to implement the ability to generate types as an option when a tag doesn't exist, as it can be useful as a foundation for static analysis.